### PR TITLE
Add support for distribution and target_controls func

### DIFF
--- a/src/aiocasambi/controller.py
+++ b/src/aiocasambi/controller.py
@@ -189,11 +189,11 @@ class Controller:
         """
         return self.units.get_unit_value(unit_id=unit_id)
 
-    def get_unit_slider(self, *, unit_id: int) -> int:
+    def get_unit_distribution(self, *, unit_id: int) -> int:
         """
-        Get the unit slider
+        Get the unit distribution
         """
-        return self.units.get_unit_slider(unit_id=unit_id)
+        return self.units.get_unit_distribution(unit_id=unit_id)
 
     async def get_unit_state(self, *, unit_id: int) -> dict:
         """
@@ -544,11 +544,11 @@ class Controller:
 
         return result
 
-    def unit_supports_slider(self, *, unit_id: int) -> bool:
+    def unit_supports_distribution(self, *, unit_id: int) -> bool:
         """
-        Check if unit supports slider
+        Check if unit supports distribution
         """
-        result = self.units.supports_slider(unit_id=unit_id)
+        result = self.units.supports_distribution(unit_id=unit_id)
 
         return result
 

--- a/src/aiocasambi/controller.py
+++ b/src/aiocasambi/controller.py
@@ -189,6 +189,12 @@ class Controller:
         """
         return self.units.get_unit_value(unit_id=unit_id)
 
+    def get_unit_slider(self, *, unit_id: int) -> int:
+        """
+        Get the unit slider
+        """
+        return self.units.get_unit_slider(unit_id=unit_id)
+
     async def get_unit_state(self, *, unit_id: int) -> dict:
         """
         Getter for getting the unit state from Casambis cloud api
@@ -535,6 +541,14 @@ class Controller:
         Check if unit supports color temperature
         """
         result = self.units.supports_brightness(unit_id=unit_id)
+
+        return result
+
+    def unit_supports_slider(self, *, unit_id: int) -> bool:
+        """
+        Check if unit supports slider
+        """
+        result = self.units.supports_slider(unit_id=unit_id)
 
         return result
 

--- a/src/aiocasambi/unit.py
+++ b/src/aiocasambi/unit.py
@@ -30,7 +30,7 @@ class Unit:
         controller,
         controls: dict,
         value: float = 0,
-        slider: float = 0,
+        distribution: float = 0,
         online: bool = True,
         enabled: bool = True,
         state: str = UNIT_STATE_OFF,
@@ -40,7 +40,7 @@ class Unit:
         self._unit_id = int(unit_id)
         self._network_id = network_id
         self._value = value
-        self._slider = slider
+        self._distribution = distribution
         self._state = state
         self._fixture_model = None
         self._fixture = None
@@ -88,32 +88,32 @@ class Unit:
             raise AiocasambiException(f"invalid value {value} for {self}")
 
     @property
-    def slider(self) -> float:
+    def distribution(self) -> float:
         """
-        Getter for slider
+        Getter for distribution
         """
-        slider = 0
+        distribution = 0
 
         if "Vertical" in self._controls:
             return self._controls["Vertical"]["value"]
         else:
-            err_msg = f"unit_id={self._unit_id} - slider - "
+            err_msg = f"unit_id={self._unit_id} - distribution - "
             err_msg += f"Vertical is missing in controls: {self._controls}"
 
             LOGGER.debug(err_msg)
 
-            return slider
+            return distribution
 
-    @slider.setter
-    def slider(self, slider: float) -> None:
+    @distribution.setter
+    def distribution(self, distribution: float) -> None:
         """
-        Setter for slider
+        Setter for distribution
         """
-        LOGGER.debug(f"unit_id={self._unit_id} - slider - setting slider to: {slider}")
-        if slider >= 0 and slider <= 1:
-            self._slider = slider
+        LOGGER.debug(f"unit_id={self._unit_id} - distribution - setting distribution to: {distribution}")
+        if distribution >= 0 and distribution <= 1:
+            self._distribution = distribution
         else:
-            raise AiocasambiException(f"invalid slider {slider} for {self}")
+            raise AiocasambiException(f"invalid distribution {distribution} for {self}")
 
     @property
     def name(self) -> str:
@@ -532,9 +532,9 @@ class Unit:
 
         await self._controller.ws_send_message(message)
 
-    async def set_unit_slider(self, *, slider: Union[float, int]) -> None:
+    async def set_unit_distribution(self, *, distribution: Union[float, int]) -> None:
         """
-        Function for setting an unit to a specific slider position
+        Function for setting an unit to a specific distribution position
 
         Response on ok:
         {'wire': 1, 'method': 'peerChanged', 'online': True}
@@ -553,10 +553,10 @@ class Unit:
                 "expected unit_id to be an integer, got: {}".format(unit_id)
             )
 
-        if not (slider >= 0 and slider <= 1):
-            raise AiocasambiException("slider needs to be between 0 and 1")
+        if not (distribution >= 0 and distribution <= 1):
+            raise AiocasambiException("distribution needs to be between 0 and 1")
 
-        target_controls = {"Vertical": {"value": slider}}
+        target_controls = {"Vertical": {"value": distribution}}
 
         message = {
             "wire": self._wire_id,
@@ -565,9 +565,9 @@ class Unit:
             "targetControls": target_controls,
         }
 
-        self.slider = slider
+        self.distribution = distribution
 
-        LOGGER.debug(f"unit_id={self._unit_id} - set_unit_slider - slider={slider}")
+        LOGGER.debug(f"unit_id={self._unit_id} - set_unit_distribution - distribution={distribution}")
 
         await self._controller.ws_send_message(message)
 
@@ -579,7 +579,7 @@ class Unit:
         {'wire': 1, 'method': 'peerChanged', 'online': True}
         """
         value = None
-        slider = None
+        distribution = None
         unit_id = self._unit_id
 
         # Unit_id needs to be an integer
@@ -606,10 +606,10 @@ class Unit:
             self.value = value
 
         if 'Vertical' in target_controls:
-            slider = target_controls['Vertical']['value']
-            self.slider = slider
+            distribution = target_controls['Vertical']['value']
+            self.distribution = distribution
 
-        LOGGER.debug(f"unit_id={self._unit_id} - set_unit_target controls - value={value}, slider={slider}")
+        LOGGER.debug(f"unit_id={self._unit_id} - set_unit_target controls - value={value}, distribution={distribution}")
 
         await self._controller.ws_send_message(message)
 
@@ -928,9 +928,9 @@ class Unit:
             return True
         return False
 
-    def supports_slider(self) -> bool:
+    def supports_distribution(self) -> bool:
         """
-        Returns true if unit supports slider
+        Returns true if unit supports distribution
 
         {
             'activeSceneId': 0,
@@ -960,7 +960,7 @@ class Unit:
         """
         if not self._controls:
             LOGGER.debug(
-                f"unit_id={self._unit_id} - supports_slider - controls is None"
+                f"unit_id={self._unit_id} - supports_distribution - controls is None"
             )
             return False
 
@@ -978,7 +978,7 @@ class Unit:
         network_id = self._network_id
 
         value = self._value
-        slider = self._slider
+        distribution = self._distribution
         state = self._state
 
         wire_id = self._wire_id
@@ -987,7 +987,7 @@ class Unit:
         result += f"unit_id={unit_id} "
         result += f"address={address} "
         result += f"value={value} "
-        result += f"slider={slider} "
+        result += f"distribution={distribution} "
         result += f"state={state} "
         result += f"online={self._online} "
         result += f"network_id={network_id} "
@@ -1007,8 +1007,8 @@ class Unit:
             result = f"{result} supports_brightness="
             result = f"{result}{self.supports_brightness()}"
 
-            result = f"{result} supports_slider="
-            result = f"{result}{self.supports_slider()}"
+            result = f"{result} supports_distribution="
+            result = f"{result}{self.supports_distribution()}"
 
             result = f"{result} supports_color_temperature="
             result = f"{result}{self.supports_color_temperature()}"

--- a/src/aiocasambi/unit.py
+++ b/src/aiocasambi/unit.py
@@ -30,6 +30,7 @@ class Unit:
         controller,
         controls: dict,
         value: float = 0,
+        slider: float = 0,
         online: bool = True,
         enabled: bool = True,
         state: str = UNIT_STATE_OFF,
@@ -39,6 +40,7 @@ class Unit:
         self._unit_id = int(unit_id)
         self._network_id = network_id
         self._value = value
+        self._slider = slider
         self._state = state
         self._fixture_model = None
         self._fixture = None
@@ -84,6 +86,34 @@ class Unit:
             self._value = value
         else:
             raise AiocasambiException(f"invalid value {value} for {self}")
+
+    @property
+    def slider(self) -> float:
+        """
+        Getter for slider
+        """
+        slider = 0
+
+        if "Vertical" in self._controls:
+            return self._controls["Vertical"]["value"]
+        else:
+            err_msg = f"unit_id={self._unit_id} - slider - "
+            err_msg += f"Vertical is missing in controls: {self._controls}"
+
+            LOGGER.debug(err_msg)
+
+            return slider
+
+    @slider.setter
+    def slider(self, slider: float) -> None:
+        """
+        Setter for slider
+        """
+        LOGGER.debug(f"unit_id={self._unit_id} - slider - setting slider to: {slider}")
+        if slider >= 0 and slider <= 1:
+            self._slider = slider
+        else:
+            raise AiocasambiException(f"invalid slider {slider} for {self}")
 
     @property
     def name(self) -> str:
@@ -502,6 +532,87 @@ class Unit:
 
         await self._controller.ws_send_message(message)
 
+    async def set_unit_slider(self, *, slider: Union[float, int]) -> None:
+        """
+        Function for setting an unit to a specific slider position
+
+        Response on ok:
+        {'wire': 1, 'method': 'peerChanged', 'online': True}
+        """
+        unit_id = self._unit_id
+
+        # Unit_id needs to be an integer
+        if isinstance(unit_id, int):
+            pass
+        elif isinstance(unit_id, str):
+            unit_id = int(unit_id)
+        elif isinstance(unit_id, float):
+            unit_id = int(unit_id)
+        else:
+            raise AiocasambiException(
+                "expected unit_id to be an integer, got: {}".format(unit_id)
+            )
+
+        if not (slider >= 0 and slider <= 1):
+            raise AiocasambiException("slider needs to be between 0 and 1")
+
+        target_controls = {"Vertical": {"value": slider}}
+
+        message = {
+            "wire": self._wire_id,
+            "method": "controlUnit",
+            "id": unit_id,
+            "targetControls": target_controls,
+        }
+
+        self.slider = slider
+
+        LOGGER.debug(f"unit_id={self._unit_id} - set_unit_slider - slider={slider}")
+
+        await self._controller.ws_send_message(message)
+
+    async def set_unit_target_controls(self, *, target_controls) -> None:
+        """
+        Function for setting an unit to specific controls
+
+        Response on ok:
+        {'wire': 1, 'method': 'peerChanged', 'online': True}
+        """
+        value = None
+        slider = None
+        unit_id = self._unit_id
+
+        # Unit_id needs to be an integer
+        if isinstance(unit_id, int):
+            pass
+        elif isinstance(unit_id, str):
+            unit_id = int(unit_id)
+        elif isinstance(unit_id, float):
+            unit_id = int(unit_id)
+        else:
+            raise AiocasambiException(
+                "expected unit_id to be an integer, got: {}".format(unit_id)
+            )
+
+        message = {
+            "wire": self._wire_id,
+            "method": "controlUnit",
+            "id": unit_id,
+            "targetControls": target_controls,
+        }
+
+        if 'Dimmer' in target_controls:
+            value = target_controls['Dimmer']['value']
+            self.value = value
+
+        if 'Vertical' in target_controls:
+            slider = target_controls['Vertical']['value']
+            self.slider = slider
+
+        LOGGER.debug(f"unit_id={self._unit_id} - set_unit_target controls - value={value}, slider={slider}")
+
+        await self._controller.ws_send_message(message)
+
     def get_supported_color_temperature(self) -> Tuple[int, int, int]:
         """
         Return the supported color temperatures,
@@ -817,6 +928,46 @@ class Unit:
             return True
         return False
 
+    def supports_slider(self) -> bool:
+        """
+        Returns true if unit supports slider
+
+        {
+            'activeSceneId': 0,
+            'address': 'ffffffffffff',
+            'condition': 0,
+            'controls': [[{'type': 'Dimmer', 'value': 0.0},
+                        {'level': 0.49736842105263157,
+                            'max': 6000,
+                            'min': 2200,
+                            'type': 'CCT',
+                            'value': 4090.0}]],
+            'dimLevel': 0.0,
+            'firmwareVersion': '26.24',
+            'fixtureId': 14235,
+            'groupId': 0,
+            'id': 13,
+            'image': 'ffffffffffffffffffffffffffffffff',
+            'name': 'Arbetslampa',
+            'on': True,
+            'online': True,
+            'position': 9,
+            'priority': 3,
+            'status': 'ok',
+            'type': 'Luminaire'
+        }
+
+        """
+        if not self._controls:
+            LOGGER.debug(
+                f"unit_id={self._unit_id} - supports_slider - controls is None"
+            )
+            return False
+
+        if "Vertical" in self._controls:
+            return True
+        return False
+
     def __repr__(self) -> str:
         """Return the representation."""
         name = self._name
@@ -827,6 +978,7 @@ class Unit:
         network_id = self._network_id
 
         value = self._value
+        slider = self._slider
         state = self._state
 
         wire_id = self._wire_id
@@ -835,6 +987,7 @@ class Unit:
         result += f"unit_id={unit_id} "
         result += f"address={address} "
         result += f"value={value} "
+        result += f"slider={slider} "
         result += f"state={state} "
         result += f"online={self._online} "
         result += f"network_id={network_id} "
@@ -853,6 +1006,9 @@ class Unit:
             # Controls state is set, not None
             result = f"{result} supports_brightness="
             result = f"{result}{self.supports_brightness()}"
+
+            result = f"{result} supports_slider="
+            result = f"{result}{self.supports_slider()}"
 
             result = f"{result} supports_color_temperature="
             result = f"{result}{self.supports_color_temperature()}"

--- a/src/aiocasambi/units.py
+++ b/src/aiocasambi/units.py
@@ -342,11 +342,11 @@ class Units:
                         f"processing_unit_event - key: {key} name: {name} msg: {msg} "
                     )
                     dbg_msg += "method unit changed control"
-                    dbg_msg += f" slider: {pformat(control['value'])}"
+                    dbg_msg += f" distribution: {pformat(control['value'])}"
                     LOGGER.debug(dbg_msg)
 
-                    # Update slider
-                    self.units[key].slider = control["value"]
+                    # Update distribution
+                    self.units[key].distribution = control["value"]
 
         return changes
 
@@ -383,13 +383,13 @@ class Units:
 
         return self.units[key].value
 
-    def get_unit_slider(self, *, unit_id: int) -> int:
+    def get_unit_distribution(self, *, unit_id: int) -> int:
         """
-        Get unit
+        Get unit distribution
         """
         key = f"{self._network_id}-{unit_id}"
 
-        return self.units[key].slider
+        return self.units[key].distribution
 
     def get_units(self) -> list:
         """
@@ -471,12 +471,12 @@ class Units:
 
         return result
 
-    def supports_slider(self, *, unit_id: int) -> bool:
+    def supports_distribution(self, *, unit_id: int) -> bool:
         """
-        Check if unit supports slider
+        Check if unit supports distribution
         """
         key = f"{self._network_id}-{unit_id}"
-        result = self.units[key].supports_slideer()
+        result = self.units[key].supports_distribution()
 
         return result
 

--- a/src/aiocasambi/units.py
+++ b/src/aiocasambi/units.py
@@ -337,6 +337,17 @@ class Units:
 
                     changes[key] = self.units[key]
 
+                if "type" in control and control["type"] == "Vertical":
+                    dbg_msg = (
+                        f"processing_unit_event - key: {key} name: {name} msg: {msg} "
+                    )
+                    dbg_msg += "method unit changed control"
+                    dbg_msg += f" slider: {pformat(control['value'])}"
+                    LOGGER.debug(dbg_msg)
+
+                    # Update slider
+                    self.units[key].slider = control["value"]
+
         return changes
 
     @property
@@ -371,6 +382,14 @@ class Units:
         key = f"{self._network_id}-{unit_id}"
 
         return self.units[key].value
+
+    def get_unit_slider(self, *, unit_id: int) -> int:
+        """
+        Get unit
+        """
+        key = f"{self._network_id}-{unit_id}"
+
+        return self.units[key].slider
 
     def get_units(self) -> list:
         """
@@ -449,6 +468,15 @@ class Units:
         """
         key = f"{self._network_id}-{unit_id}"
         result = self.units[key].supports_brightness()
+
+        return result
+
+    def supports_slider(self, *, unit_id: int) -> bool:
+        """
+        Check if unit supports slider
+        """
+        key = f"{self._network_id}-{unit_id}"
+        result = self.units[key].supports_slideer()
 
         return result
 


### PR DESCRIPTION
Ok, all good things come in threes. Sorry for the PR confusion, but I am still learning the git interactions. I now cleaned up the commit history and resubmitted the changes in a new PR.

This adds a set_unit_distribution function to control the 'Vertical' control of Casambi API. It also adds the set_unit_target_controls function to be able to use individual controls. Class representation is updated as well.

Please review and merge if ok.